### PR TITLE
, select schema at import

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,14 @@
       <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
+    <style>
+      .v-btn--fab.v-size--small {
+        /* fix #15 */
+        width:30px;height:30px;
+        margin-top: 15px;
+        margin-bottom: 15px;
+      }
+      </style>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/src/models/mcf/model.json
+++ b/src/models/mcf/model.json
@@ -331,7 +331,6 @@
                     "type": "string",
                     "description": "method used to represent geographic information in the dataset",
                     "enum": [
-                        "",
                         "vector",
                         "grid",
                         "textTable",
@@ -344,7 +343,6 @@
                     "type": "string",
                     "description": "name of point or vector objects used to locate zero-, one-, two-, or threedimensional spatial locations in the dataset",
                     "enum": [
-                        "",
                         "complex",
                         "composite",
                         "curve",
@@ -363,7 +361,6 @@
                     "type": "string",
                     "description": "Content type",
                     "enum": [
-                        "",
                         "grid",
                         "image",
                         "coverage",
@@ -457,11 +454,7 @@
                         ]
                     }
                 }
-            },
-            "required": [
-                "type",
-                "dimensions"
-            ]
+            }
         },
         "contact": {
             "title": "Contact information",

--- a/src/models/mcf/template.json
+++ b/src/models/mcf/template.json
@@ -13,8 +13,8 @@
         "datestamp": ""  
     },
     "spatial": {
-        "datatype": "",
-        "geomtype": ""
+        "datatype": null,
+        "geomtype": null
     },
     "distribution": [
         {


### PR DESCRIPTION
This brings in option to add additional import schema's, when supported by pygeometa (fgdc, oarec, stac)

<img width="433" alt="image" src="https://user-images.githubusercontent.com/299829/234557281-ccd4bccc-77de-411b-b13e-d522571ab56c.png">

also:
- move doi to import
- layout fixes
- use null instead of '' for enums' default value, else invalidates